### PR TITLE
Update info/1 directives for the preferred format for versions and dates in Logtalk 3.36.0

### DIFF
--- a/action.lgt
+++ b/action.lgt
@@ -1,9 +1,9 @@
 :- category(action,
     implements(action_protocol)).
 
-    :- info([ version is 1.1
+    :- info([ version is 1:1:0
             , author is 'Paul Brown'
-            , date is 2019/11/2
+            , date is 2019-11-02
             , comment is 'An action to be extended by domain actions.'
             ]).
 

--- a/fluent.lgt
+++ b/fluent.lgt
@@ -1,9 +1,9 @@
 :- category(fluent,
     implements(fluent_protocol)).
 
-    :- info([ version is 1.1
+    :- info([ version is 1:1:0
             , author is 'Paul Brown'
-            , date is 2019/11/2
+            , date is 2019-11-02
             , comment is 'A fluent is a prototype. It is identified by the relationship that can hold in some situations. The value(s) this relationship holds between in a situation, if any, depend upon the situation'
             ]).
 

--- a/fluent_tabled.lgt
+++ b/fluent_tabled.lgt
@@ -1,9 +1,9 @@
 :- category(fluent,
     implements(fluent_protocol)).
 
-    :- info([ version is 1.1
+    :- info([ version is 1:1:0
             , author is 'Paul Brown'
-            , date is 2019/11/2
+            , date is 2019-11-02
             , comment is 'A fluent is a prototype. It is identified by the relationship that can hold in some situations. The value(s) this relationship holds between in a situation, if any, depend upon the situation'
             ]).
 

--- a/sitcalc.lgt
+++ b/sitcalc.lgt
@@ -2,9 +2,9 @@
     imports(situation_query),
     implements(situation_protocol)).
 
-    :- info([ version is 1.1
+    :- info([ version is 1:1:0
             , author is 'Paul Brown'
-            , date is 2019/11/2
+            , date is 2019-11-02
             , comment is 'A situation is defined by its history of actions.'
             ]).
 

--- a/tests.lgt
+++ b/tests.lgt
@@ -2,9 +2,9 @@
 	extends(lgtunit)).
 
 	:- info([
-		version is 1.3,
+		version is 1:3:0,
 		author is 'Paul Brown',
-		date is 2020/11/3,
+		date is 2020-11-03,
 		comment is 'Unit tests for SitCalc.'
 	]).
 


### PR DESCRIPTION
Note that this PR makes Logtalk 3.36.0 the minimum required version.